### PR TITLE
Stderr word fix

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -4,3 +4,4 @@
 <!-- [SocialUsernameName](Profile-Url) (**Your Name**) - _Description of your contribution in a few words_ -->
 
 - [IgnisDa](https://github.com/IgnisDa/) (**Diptesh Choudhuri**) - _Initial work_
+- [flyingcakes85](https://github.com/flyingcakes85/) **Snehit Sah** - _Fix typo_

--- a/src/app.rs
+++ b/src/app.rs
@@ -534,7 +534,7 @@ fn switch_error(args: &mut Vec<CustomArg>) {
     const SHORT: &str = "Print to stderr instead of stdout";
     const LONG: &str = long!(
         "\
-If this switch is supplied, the output will be printed to stdout.
+If this switch is supplied, the output will be printed to stderr.
 This can then be piped as required.
 
 Example:


### PR DESCRIPTION
Fix one instance of `stdout` that should've been `stderr`.